### PR TITLE
Make BS neuron spontaneous state JSON-safe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 joblib
 numpy==2.2.4
 psutil
+scipy

--- a/src/components/NES_interfaces/BS_Neuron.py
+++ b/src/components/NES_interfaces/BS_Neuron.py
@@ -123,8 +123,7 @@ class BS_Neuron(Neuron):
             'vPSP': self.vPSP,
 
             'tau_spont_mean_stdev_ms': self.tau_spont_mean_stdev_ms,
-            't_spont_next': self.t_spont_next, # TODO: Should this be here?
-            'dt_spont_dist': self.dt_spont_dist, # TODO: Should this be here?
+            't_spont_next': self.t_spont_next,
 
             'morphology': morphology,
             'receptors': receptors,

--- a/src/components/prototyping/BS_Neuron.py
+++ b/src/components/prototyping/BS_Neuron.py
@@ -121,6 +121,9 @@ class BS_Neuron(Neuron):
         self.tau_spont_mean_stdev_ms = mean_stdev
         mu = self.tau_spont_mean_stdev_ms[0]
         sigma = self.tau_spont_mean_stdev_ms[1]
+        if mu == 0 or sigma == 0:
+            self.dt_spont_dist = None
+            return
         a, b = 0, 2*mu
         self.dt_spont_dist = stats.truncnorm((a - mu) / sigma, (b - mu) / sigma, loc=mu, scale=sigma)
 
@@ -145,8 +148,7 @@ class BS_Neuron(Neuron):
             'vPSP': self.vPSP,
 
             'tau_spont_mean_stdev_ms': self.tau_spont_mean_stdev_ms,
-            't_spont_next': self.t_spont_next, # TODO: Should this be here?
-            'dt_spont_dist': self.dt_spont_dist, # TODO: Should this be here?
+            't_spont_next': self.t_spont_next,
 
             'morphology': morphology,
             'receptors': receptors,
@@ -167,9 +169,8 @@ class BS_Neuron(Neuron):
         self.tau_PSPd = cell_data['tau_PSPd']
         self.vPSP = cell_data['vPSP']
 
-        self.tau_spont_mean_stdev_ms = cell_data['tau_spont_mean_stdev_ms']
-        self.t_spont_next = cell_data['t_spont_next'] # TODO: Should this be here?
-        self.dt_spont_dist = cell_data['dt_spont_dist'] # TODO: Should this be here?
+        self.set_spontaneous_activity(tuple(cell_data['tau_spont_mean_stdev_ms']))
+        self.t_spont_next = cell_data['t_spont_next']
 
         self.t_directstim_ms = cell_data['t_directstim_ms']
         self.receptors = cell_data['receptors'] # This needs follow-up conversion to references in System.from_dict().


### PR DESCRIPTION
## Summary
- stop serializing the SciPy spontaneous-activity distribution object from BS neuron `to_dict()` output
- reconstruct the prototype BS neuron distribution from `tau_spont_mean_stdev_ms` during `from_dict()`
- keep `t_spont_next` as resumable simulation state and guard disabled spontaneous activity from creating an invalid distribution
- add the direct `scipy` dependency already required by these components

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3 -m py_compile src/components/prototyping/BS_Neuron.py src/components/NES_interfaces/BS_Neuron.py src/components/prototyping/System.py`
- `python3.10 -m venv /tmp/bec-bs-neuron-venv && /tmp/bec-bs-neuron-venv/bin/pip install -r requirements.txt`
- focused Python 3.10 probe confirming prototype BS neurons JSON-serialize after spontaneous activity, reload reconstructs `dt_spont_dist`, disabled spontaneous activity stays safe, and the NES-interface `to_dict()` omits `dt_spont_dist`
- `git diff --check`
- clean patch apply to a temporary `origin/main` worktree

## Local note
- The default `python3` on this machine is Python 3.14, where the pinned `numpy==2.2.4` does not have a wheel and starts a source build. Verification used `python3.10`, which has compatible wheels for the pinned dependency set.
