### PR TITLE
Bound NES interface run waits

### DIFF
--- a/src/components/NES_interfaces/System.py
+++ b/src/components/NES_interfaces/System.py
@@ -6,7 +6,7 @@ Definitions of in-silico ground-truth systems.
 '''
 
 import matplotlib.pyplot as plt
-from time import sleep
+from time import monotonic, sleep
 import json
 
 import common.glb as glb
@@ -55,11 +55,15 @@ class System:
     def get_recording(self)->dict:
         return glb.bg_api.BGNES_get_recording()
 
-    def run_for(self, t_run_ms:float, blocking=True):
+    def run_for(self, t_run_ms:float, blocking=True, timeout_s:float=300.0):
         glb.bg_api.BGNES_simulation_runfor(t_run_ms)
         if not blocking: return
-        # TODO: *** Beware that the following can get stuck.
+        if timeout_s is not None and timeout_s < 0:
+            raise ValueError('timeout_s must be nonnegative or None')
+        deadline_s = None if timeout_s is None else monotonic() + timeout_s
         while glb.bg_api.BGNES_get_simulation_status()[0]:
+            if deadline_s is not None and monotonic() >= deadline_s:
+                raise TimeoutError('NES simulation did not finish within %s seconds' % timeout_s)
             sleep(0.005)
 
     def to_dict(self)->dict:


### PR DESCRIPTION
## Summary
- add a default 300 second timeout to blocking `NES_interfaces.System.run_for()` waits
- allow callers to pass `timeout_s=None` for the old indefinite wait behavior or a custom timeout for long runs
- reject negative timeout values before polling

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bec-bs-neuron-venv/bin/python -m py_compile src/components/NES_interfaces/System.py`
- focused fake-API probe covering completed runs, timeout raises, nonblocking mode, and negative timeout validation
- `git diff --check`
- clean patch apply to a temporary `origin/main` worktree
