### PR TITLE
Fix AIFinch prototype imports and constructor

### DIFF
--- a/src/models/e3_aifinch/aifinch_vbp1_acquisition.py
+++ b/src/models/e3_aifinch/aifinch_vbp1_acquisition.py
@@ -7,7 +7,7 @@ This file is used to generate a simulated data acquisition protocol that is appl
 the ground-truth system that was generated with aifinch_groundtruth.py.
 '''
 
-import aifinch_groundtruth as kgt
+import aifinch_vbp0_groundtruth as kgt
 
 # == Functional Recording Procedures: ===================================================================
 
@@ -35,11 +35,11 @@ class EFP_ElectrodeArray:
         target_region:kgt.Region,
         num_electrodes:int=10,
         sites_per_electrode:int=1,
-        electrode_placement:Placement):
+        electrode_placement:Placement=None):
         self.target_region = target_region
         self.num_electrodes = num_electrodes
         self.sites_per_electrode = sites_per_electrode
-        self.electrode_placement = electrode_placement
+        self.electrode_placement = electrode_placement if electrode_placement is not None else Placement()
 
     def show(self):
         pass

--- a/src/models/e3_aifinch/aifinch_vbp2_translation.py
+++ b/src/models/e3_aifinch/aifinch_vbp2_translation.py
@@ -8,8 +8,8 @@ data acquired with aifinch_acquisition.py, with model selection and parameter
 estimation steps. The result is one or more possible AIFinch emulation representations.
 '''
 
-import aifinch_groundtruth as kgt
-import aifinch_acquisition as acq
+import aifinch_vbp0_groundtruth as kgt
+import aifinch_vbp1_acquisition as acq
 
 # == Layout Identification and Translation: =============================================================
 

--- a/src/models/e3_aifinch/aifinch_vbp3_emulation.py
+++ b/src/models/e3_aifinch/aifinch_vbp3_emulation.py
@@ -6,9 +6,11 @@
 This file is used to run, validate and test AIFinch emulations that were
 generated with aifinch_translation.py.
 '''
-import aifinch_groundtruth as kgt
-import aifinch_acquisition as acq
-import aifinch_translation as sit
+from __future__ import annotations
+
+import aifinch_vbp0_groundtruth as kgt
+import aifinch_vbp1_acquisition as acq
+import aifinch_vbp2_translation as sit
 
 # == EM Model Building: =================================================================================
 


### PR DESCRIPTION
## Summary
- fix `EFP_ElectrodeArray` so its optional constructor arguments are syntactically valid
- default missing electrode placement to a base `Placement`
- update the versioned AIFinch prototype modules to import the versioned sibling files that actually exist
- postpone emulation module type annotations so the prototype can be imported before placeholder classes are implemented

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 /tmp/bec-bs-neuron-venv/bin/python -m py_compile src/models/e3_aifinch/aifinch_vbp1_acquisition.py src/models/e3_aifinch/aifinch_vbp2_translation.py src/models/e3_aifinch/aifinch_vbp3_emulation.py`
- focused import/constructor probe for the AIFinch acquisition, translation, and emulation modules
- `git diff --check`
- clean patch apply to a temporary `origin/main` worktree
