### PR TITLE
Fix receptor interface syntax errors

### DIFF
--- a/src/components/NES_interfaces/NES_AMPA_Receptor.py
+++ b/src/components/NES_interfaces/NES_AMPA_Receptor.py
@@ -34,9 +34,10 @@ class NES_AMPA_Receptor:
 			g_peak_pS_init:float=39,
 			a_norm_init:float=1.0,
 		)->None:
+		self.ID = ID
 		API_call(
 				'NES/AMPAR/init',
-				json.dumps(
+				json.dumps({
 						'ID': ID,
 						'Gsyn_pS_init': Gsyn_pS_init,
 						'Esyn_mV_init': Esyn_mV_init,
@@ -52,15 +53,15 @@ class NES_AMPA_Receptor:
 						'x_init': x_init,
 						'g_peak_pS_init': g_peak_pS_init,
 						'a_norm_init': a_norm_init,
-					),
+					}),
 			)
 	def set_psp_type(self, psp_type:str):
 		API_call(
 				'NES/AMPAR/set_psp_type',
-				json.dumps(
-						'ID': ID,
+				json.dumps({
+						'ID': self.ID,
 						'psp_type': psp_type, # 'dblexp' or 'mxh'
-					)
+					})
 			)
 	# PROPOSAL 1: Waiting for a response can be a blocking await function as
 	# shown here.
@@ -69,12 +70,12 @@ class NES_AMPA_Receptor:
 	def np_Gsyn_t_pS_dbl(self, t_ms:np.ndarray)->np.ndarray:
 		API_call(
 				'NES/AMPAR/np_Gsyn_t_pS_dbl',
-				json.dumps(
-						'ID': ID,
-						't_ms': t_ms,
-					)
+				json.dumps({
+						'ID': self.ID,
+						't_ms': t_ms.tolist(),
+					})
 			)
-		resp = await_API_response('NES/AMPAR/np_Gsyn_t_pS_dbl', ID)
+		resp = await_API_response('NES/AMPAR/np_Gsyn_t_pS_dbl', self.ID)
 		if resp is None:
 			raise Exception(get_API_error())
 		if 'error' in resp:
@@ -86,22 +87,22 @@ class NES_AMPA_Receptor:
 	def np_Gsyn_t_pS_dbl_withcallback(self, t_ms:np.ndarray)->bool:
 		API_call(
 				'NES/AMPAR/np_Gsyn_t_pS_dbl',
-				json.dumps(
-						'ID': ID,
-						't_ms': t_ms,
-					)
+				json.dumps({
+						'ID': self.ID,
+						't_ms': t_ms.tolist(),
+					}),
 				callback=self.np_Gsyn_t_pS_dbl_handle
 			)
 		return True
 	def np_Gsyn_t_pS_mxh(self, t_ms:np.ndarray)->np.ndarray:
 		API_call(
 				'NES/AMPAR/np_Gsyn_t_pS_mxh',
-				json.dumps(
-						'ID': ID,
-						't_ms': t_ms,
-					)
+				json.dumps({
+						'ID': self.ID,
+						't_ms': t_ms.tolist(),
+					})
 			)
-		resp = await_API_response('NES/AMPAR/np_Gsyn_t_pS_mxh', ID)
+		resp = await_API_response('NES/AMPAR/np_Gsyn_t_pS_mxh', self.ID)
 		if resp is None:
 			raise Exception(get_API_error())
 		if 'error' in resp:
@@ -110,10 +111,10 @@ class NES_AMPA_Receptor:
 	def np_Gsyn_t_pS_mxh_withcallback(self, t_ms:np.ndarray)->bool:
 		API_call(
 				'NES/AMPAR/np_Gsyn_t_pS_mxh',
-				json.dumps(
-						'ID': ID,
-						't_ms': t_ms,
-					)
+				json.dumps({
+						'ID': self.ID,
+						't_ms': t_ms.tolist(),
+					}),
 				callback=self.np_Gsyn_t_pS_mxh_handle
 			)
 		return True

--- a/src/components/NES_interfaces/NMDA_Receptor.py
+++ b/src/components/NES_interfaces/NMDA_Receptor.py
@@ -68,14 +68,14 @@ class NMDA_Receptor(AMPA_Receptor):
 		Modeled with a Bolzmann function.
 		Easy to use, but not directly related to physical aspects of Mg2+ blocking mechanism.
 		'''
-		return 1.0 / ( 1.0 + exp(-(self.Vm - self.V_halfblocked)/self.k_init) )
+		return 1.0 / ( 1.0 + exp(-(self.Vm_mV - self.V_halfblocked)/self.k) )
 
 	def Phi(self,
 			T:float,	# Absolute temperature.
 			z=2,		# Valenve of blocking ion (+2 for Mg2+).
 		)->float:
 		R = 8.31446261815324	# Gas constant (in J/(K*mol)).
-		F = 96 485.3321			# Faraday constant (in s*A/mol).
+		F = 96485.3321			# Faraday constant (in s*A/mol).
 		return z*F / (R*T)
 
 	def k_binding_rate(self,

--- a/src/components/prototyping/NMDA_Receptor.py
+++ b/src/components/prototyping/NMDA_Receptor.py
@@ -68,14 +68,14 @@ class NMDA_Receptor(AMPA_Receptor):
 		Modeled with a Bolzmann function.
 		Easy to use, but not directly related to physical aspects of Mg2+ blocking mechanism.
 		'''
-		return 1.0 / ( 1.0 + exp(-(self.Vm - self.V_halfblocked)/self.k_init) )
+		return 1.0 / ( 1.0 + exp(-(self.Vm_mV - self.V_halfblocked)/self.k) )
 
 	def Phi(self,
 			T:float,	# Absolute temperature.
 			z=2,		# Valenve of blocking ion (+2 for Mg2+).
 		)->float:
 		R = 8.31446261815324	# Gas constant (in J/(K*mol)).
-		F = 96 485.3321			# Faraday constant (in s*A/mol).
+		F = 96485.3321			# Faraday constant (in s*A/mol).
 		return z*F / (R*T)
 
 	def k_binding_rate(self,


### PR DESCRIPTION
Summary:
- fix NES AMPA receptor JSON payload construction and instance ID usage
- serialize numpy time arrays before API calls
- fix NMDA receptor syntax/name errors in NES and prototyping modules

Verification:
- PYTHONDONTWRITEBYTECODE=1 /tmp/bec-bs-neuron-venv/bin/python -m py_compile src/components/NES_interfaces/NES_AMPA_Receptor.py src/components/NES_interfaces/NMDA_Receptor.py src/components/prototyping/NMDA_Receptor.py
- focused receptor import/API payload probe
- git diff --check
- clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.