### PR TITLE
Fix electrode site centerline direction

### DIFF
--- a/src/components/prototyping/Electrodes.py
+++ b/src/components/prototyping/Electrodes.py
@@ -53,7 +53,7 @@ class Recording_Electrode:
 		2. Multiply vector coordinates with the ratios given in eloc_ratio.
 		3. Add the resulting vector to the tip position.
 		'''
-		tip_to_end = self.tip_position - self.end_position
+		tip_to_end = self.end_position - self.tip_position
 		vec_to_add = tip_to_end * eloc_ratio[2]
 		sysloc_um = self.tip_position + vec_to_add
 		return sysloc_um


### PR DESCRIPTION
Summary
- Correct prototyping recording-electrode site placement so the centerline vector points from tip to end.
- Preserve the existing ratio-based placement behavior while fixing the sign of the displacement.

Verification
- PYTHONDONTWRITEBYTECODE=1 /tmp/bec-bs-neuron-venv/bin/python -B -m py_compile src/components/prototyping/Electrodes.py
- Focused probe with tip `(0, 0, 0)`, end `(0, 0, 10)`, and site ratios `0`/`1`, asserting locations `[[0, 0, 0], [0, 0, 10]]`.
- git diff --check
- Clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.
