### PR TITLE
Complete prototyping component lookup

### DIFF
--- a/src/components/prototyping/System.py
+++ b/src/components/prototyping/System.py
@@ -40,10 +40,30 @@ class System:
         '''
         Runs a specified function in any component in the System that matches id.
         '''
-        # TODO: Complete this.
-        component = None
-        result = None
-        return result
+        component = self.neuralcircuits.get(component_id)
+        if component is None:
+            component = self.regions.get(component_id)
+        if component is None:
+            for neuron in self.get_all_neurons():
+                if neuron.id == component_id:
+                    component = neuron
+                    break
+        if component is None:
+            for electrode in self.recording_electrodes:
+                if electrode.id == component_id:
+                    component = electrode
+                    break
+        if component is None and self.calcium_imaging is not None and self.calcium_imaging.id == component_id:
+            component = self.calcium_imaging
+
+        if component is None:
+            return None
+
+        component_method = getattr(component, component_function, None)
+        if not callable(component_method):
+            return None
+
+        return component_method()
 
     def add_circuit(self, circuit:NeuralCircuit)->NeuralCircuit:
         self.neuralcircuits[circuit.id] = circuit


### PR DESCRIPTION
## Summary
- implement `System.component_by_id()` for prototyping systems
- search circuits, regions, neurons, recording electrodes, and calcium imaging by component ID
- return `None` for missing components, missing methods, or non-callable attributes

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3.10 -m py_compile src/components/prototyping/System.py`
- focused import-stub probe covering circuit, region, neuron, electrode, calcium imaging, missing-ID, missing-method, and non-callable-attribute lookups
- `git diff --check`
- clean patch apply against a fresh `origin/main` checkout with `git apply --check --whitespace=error-all`

The focused runtime probe used import stubs because the bare local Python 3.10 environment does not have `matplotlib` installed.
