### PR TITLE
Handle zero-length cylinder voxels

### DIFF
--- a/src/components/common/_Geometry.py
+++ b/src/components/common/_Geometry.py
@@ -360,6 +360,15 @@ class _Cylinder(Geometry):
         xyz_end = np.array(list(self.end1_um))
         dxyz = xyz_end - xyz_start
         mag_dxyz = np.sqrt(dxyz.dot(dxyz))
+        if mag_dxyz == 0:
+            voxelspecs = voxel_containing_point(xyz_start, voxel_um)
+            voxels_dict[voxelspecs['key']] = fluorescent_voxel(
+                voxelspecs['center'],
+                voxel_um,
+                neuron,
+                type_brightness=3.0)
+            return voxels_dict
+
         dxyz = (voxel_um/mag_dxyz)*dxyz
         xyz = xyz_start
         d = 0


### PR DESCRIPTION
## Summary
- guard `_Cylinder.get_voxels()` against zero-length cylinders before normalizing the axis vector
- return the voxel containing the shared endpoint for degenerate cylinders, preserving the existing cylinder brightness path

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3.10 -m py_compile src/components/common/_Geometry.py`
- focused import-stub probe covering zero-length and normal cylinder voxel generation
- `rg -n "mag_dxyz == 0|voxel_containing_point\\(xyz_start" src/components/common/_Geometry.py`
- `git diff --check`
- clean patch apply against a fresh `origin/main` checkout with `git apply --check --whitespace=error-all`

The focused runtime probe used dependency stubs because the local Python environments do not have the full scientific plotting stack installed.
