### PR TITLE
Guard N1 empty KGT percentage

### DIFF
--- a/src/components/NES_interfaces/Metrics_N1.py
+++ b/src/components/NES_interfaces/Metrics_N1.py
@@ -53,7 +53,10 @@ class Metrics_N1:
         kgt_num_neurons = len(self.kgt.get_all_neurons())
 
         num_neurons_difference = abs(emulation_num_neurons - kgt_num_neurons)
-        percentage_difference = (num_neurons_difference / kgt_num_neurons) * 100
+        if kgt_num_neurons == 0:
+            percentage_difference = 0 if emulation_num_neurons == 0 else 100
+        else:
+            percentage_difference = (num_neurons_difference / kgt_num_neurons) * 100
 
         # get connectivity matrix
         connectivity_matrix_kgt = self.build_connectivity_matrix(self.kgt)

--- a/src/components/prototyping/Metrics_N1.py
+++ b/src/components/prototyping/Metrics_N1.py
@@ -55,7 +55,10 @@ class Metrics_N1:
         kgt_num_neurons = len(self.kgt.get_all_neurons())
 
         num_neurons_difference = abs(emulation_num_neurons - kgt_num_neurons)
-        percentage_difference = (num_neurons_difference / kgt_num_neurons) * 100
+        if kgt_num_neurons == 0:
+            percentage_difference = 0 if emulation_num_neurons == 0 else 100
+        else:
+            percentage_difference = (num_neurons_difference / kgt_num_neurons) * 100
 
         # get connectivity matrix
         connectivity_matrix_kgt = self.build_connectivity_matrix(self.kgt)


### PR DESCRIPTION
## Summary
- avoid division by zero when N1 metrics compare against an empty KGT system
- return `0%` difference when both systems are empty and `100%` when only the KGT is empty
- apply the same guard to prototyping and NES-interface N1 metrics

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3.10 -m py_compile src/components/prototyping/Metrics_N1.py src/components/NES_interfaces/Metrics_N1.py`
- focused percentage calculation probe for `(0,0)`, `(3,0)`, `(3,6)`, and `(6,3)` neuron counts
- `rg -n "kgt_num_neurons == 0|percentage_difference = \\(num_neurons_difference / kgt_num_neurons\\)" src/components/prototyping/Metrics_N1.py src/components/NES_interfaces/Metrics_N1.py`
- `git diff --check`
- clean patch apply against a fresh `origin/main` checkout with `git apply --check --whitespace=error-all`
