### PR TITLE
Fix Spatial vec3sub helper

### DIFF
--- a/src/components/common/Spatial.py
+++ b/src/components/common/Spatial.py
@@ -47,7 +47,7 @@ def vec3add(v1:tuple, v2:tuple)->tuple:
     return ( v1[0]+v2[0], v1[1]+v2[1], v1[2]+v2[2] )
 
 def vec3sub(v:tuple, vsub:tuple)->tuple:
-    return ( v1[0]-v2[0], v1[1]-v2[1], v1[2]-v2[2] )
+    return ( v[0]-vsub[0], v[1]-vsub[1], v[2]-vsub[2] )
 
 def get_cube_vertices(cube_definition:list)->np.array:
     # Interpret the minimal cube definition:


### PR DESCRIPTION
## Summary
- fix `vec3sub(v, vsub)` to subtract the provided arguments instead of undefined `v1`/`v2` names
- keep `vec3add` behavior unchanged

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3.10 -m py_compile src/components/common/Spatial.py`
- focused import-stub probe for `vec3sub((5,7,11), (2,3,5)) == (3,4,6)` and existing `vec3add`
- confirmed no open PR currently touches `src/components/common/Spatial.py`
- `git diff --check`
- clean patch apply against a fresh `origin/main` checkout with `git apply --check --whitespace=error-all`
