### PR TITLE
Mark XOR groundtruth diagrams raw

### DIFF
--- a/src/models/xor_bs/xor_bs_groundtruth_simplified.py
+++ b/src/models/xor_bs/xor_bs_groundtruth_simplified.py
@@ -67,7 +67,7 @@ bg_api.BGNES_simulation_create(name=sys_name, seed=randomseed)
 
 # 3. Define ground-truth model
 
-INITTEXT1='''
+INITTEXT1=r'''
 1. Defining an XOR logic circuit composed of ball-and-stick
    principal neurons and interneurons. The network and its
    connectivity are specified explicitly.

--- a/src/models/xor_sc/xor_sc_groundtruth.py
+++ b/src/models/xor_sc/xor_sc_groundtruth.py
@@ -74,7 +74,7 @@ bg_api.BGNES_simulation_create(name=sys_name, seed=randomseed)
 
 # 3. Define ground-truth model
 
-INITTEXT1='''
+INITTEXT1=r'''
 1. Defining an XOR logic circuit composed of SimpleCompartmental
    principal neurons and interneurons. The network and its
    connectivity are specified explicitly.


### PR DESCRIPTION
## Summary
- mark XOR groundtruth diagram strings as raw string literals
- preserve the printed ASCII diagrams while avoiding invalid escape warnings from backslashes

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3.10 -m py_compile src/models/xor_sc/xor_sc_groundtruth.py src/models/xor_bs/xor_bs_groundtruth_simplified.py`
- `python3.14 -m py_compile src/models/xor_sc/xor_sc_groundtruth.py src/models/xor_bs/xor_bs_groundtruth_simplified.py`
- `rg -n "INITTEXT1=r'''|INITTEXT1='''" src/models/xor_sc/xor_sc_groundtruth.py src/models/xor_bs/xor_bs_groundtruth_simplified.py`
- `git diff --check`
- clean patch apply against a fresh `origin/main` checkout with `git apply --check --whitespace=error-all`
