### PR TITLE
Use merged calcium imaging defaults

### DIFF
--- a/src/components/prototyping/Calcium_Imaging.py
+++ b/src/components/prototyping/Calcium_Imaging.py
@@ -68,12 +68,12 @@ class Calcium_Imaging:
         }
         self.specs.update(specs)
 
-        self.id = specs['id']
-        self.fluorescing_neurons = specs['fluorescing_neurons']
-        self.calcium_indicator = specs['calcium_indicator']
-        self.indicator_rise_ms = specs['indicator_rise_ms']
-        self.indicator_decay_ms = specs['indicator_decay_ms']
-        self.indicator_interval_ms = specs['indicator_interval_ms']
+        self.id = self.specs['id']
+        self.fluorescing_neurons = self.specs['fluorescing_neurons']
+        self.calcium_indicator = self.specs['calcium_indicator']
+        self.indicator_rise_ms = self.specs['indicator_rise_ms']
+        self.indicator_decay_ms = self.specs['indicator_decay_ms']
+        self.indicator_interval_ms = self.specs['indicator_interval_ms']
         #self.microscope_lensfront_position_um = specs['microscope_lensfront_position_um']
         #self.microscope_rear_position_um = specs['microscope_rear_position_um']
         self.system_ref = system_ref


### PR DESCRIPTION
Summary:
- read Calcium_Imaging constructor fields from the merged self.specs defaults
- allow partial specs dictionaries to override only the fields they provide

Verification:
- python3.10 -m py_compile src/components/prototyping/Calcium_Imaging.py
- source probe confirming old direct specs reads are gone
- focused import-stub constructor probe for empty and partial specs
- git diff --check
- clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.