### PR TITLE
Guard autoassociative CPU count fallback

### DIFF
--- a/src/models/autoassociative/gen_autonm_labels.py
+++ b/src/models/autoassociative/gen_autonm_labels.py
@@ -479,7 +479,7 @@ if __name__ == '__main__':
     }
 
     # Determine total and batch sizes
-    logicalCPUs = os.cpu_count()
+    logicalCPUs = max(1, os.cpu_count() or 1)
     numsamples = df.shape[0] # Args.batchsize
     batchsize = numsamples
     if Args.batchlimit > 0:


### PR DESCRIPTION
Summary:
- clamp gen_autonm_labels.py logical CPU detection to at least one CPU
- prevent -fitcpus batch sizing from comparing against None when os.cpu_count() is unavailable

Verification:
- python3.10 -m py_compile src/models/autoassociative/gen_autonm_labels.py
- source probe confirming the fallback expression replaced the raw os.cpu_count() assignment
- focused batch-size probe for cpu_count None, 0, 2, no-fitcpus, and explicit batchlimit cases
- git diff --check
- clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.