### PR TITLE
Sleep while neuroglancer test idles

### DIFF
--- a/NeuroglancerTests/Neuroglancer.py
+++ b/NeuroglancerTests/Neuroglancer.py
@@ -1,4 +1,5 @@
 import neuroglancer
+from time import sleep
 
 ip = '0.0.0.0' # or public IP of the machine for sharable display
 port = 8080 # change to an unused port number
@@ -14,4 +15,4 @@ print(viewer)
 
 
 while True:
-    pass
+    sleep(1)


### PR DESCRIPTION
Summary:
- replace the Neuroglancer test viewer's busy-spin idle loop with a one-second sleep
- keep the viewer process alive without pinning a CPU core

Verification:
- py_compile NeuroglancerTests/Neuroglancer.py using a temporary pyc path
- focused stub probe for neuroglancer plus time.sleep, confirming one sleep(1) call
- source probe confirming the busy pass loop is gone
- git diff --check
- clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.