### PR TITLE
Fix sliceviewer option parsing

### DIFF
--- a/Challenge/examples/sliceviewer.py
+++ b/Challenge/examples/sliceviewer.py
@@ -31,6 +31,12 @@ default_path = None
 default_sidesize = None
 default_overlap = None
 default_interpolation = None
+
+def normalize_interpolation(interpolation_value):
+    if interpolation_value[0].lower() == 'a':
+        return 'area'
+    return 'cubic'
+
 try:
     with open('.sliceviewer-dir','r') as f:
         data = json.load(f)
@@ -65,6 +71,8 @@ else:
         sidesize = input('Stiched side size in px (def.=%d): ' % default_sidesize)
         if sidesize == '':
             sidesize = default_sidesize
+        else:
+            sidesize = int(sidesize)
     else:
         sidesize = input('Stiched side size in px: ')
         if sidesize == '':
@@ -89,27 +97,21 @@ else:
             overlap = int(overlap)
 
 if Args.interpolation:
-    interpolation = float(Args.interpolation)
+    interpolation = normalize_interpolation(Args.interpolation)
 else:
     if default_interpolation:
         interpolation = input('Interpolation [c]ubic/[a]rea (def.=%s): ' % default_interpolation)
         if interpolation == '':
             interpolation = default_interpolation
         else:
-            if interpolation[0] == 'a':
-                interpolation = 'area'
-            else:
-                interpolation = 'cubic'
+            interpolation = normalize_interpolation(interpolation)
     else:
         interpolation = input('Interpolation [c]ubic/[a]rea: ')
         if interpolation == '':
             print('Missing interpolation.')
             exit(1)
         else:
-            if interpolation[0] == 'a':
-                interpolation = 'area'
-            else:
-                interpolation = 'cubic'
+            interpolation = normalize_interpolation(interpolation)
 
 maxcontrast = (input('Maximize contrast? (y/N) ') == 'y')
 


### PR DESCRIPTION
Summary:
- parse --interpolation as the viewer's area/cubic option instead of converting it to float
- reuse the same interpolation normalization for CLI and interactive input
- convert non-default sidesize input to int when a saved default exists

Verification:
- py_compile Challenge/examples/sliceviewer.py using a temporary pyc path
- focused AST probe for normalize_interpolation() and sidesize int conversion
- git diff --check
- clean patch apply against origin/main

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.