### PR TITLE
Fix submission calcium plot axes

### DIFF
--- a/Challenge/SubmissionConverter/SubmissionVisualizer.py
+++ b/Challenge/SubmissionConverter/SubmissionVisualizer.py
@@ -406,9 +406,7 @@ else:
                 if len(neuron_Ca_data) < 1:
                     print('No Calcium concentration data for neuron '+neuron_id)
                 else:
-                    fig = plt.figure(figsize=figspecs['figsize'])
-                    gs = fig.add_gridspec(len(E_mV),1, hspace=0)
-                    axs = gs.subplots(sharex=True, sharey=True)
+                    fig, axs = plt.subplots(figsize=figspecs['figsize'])
                     axs.set_xlabel("Time (ms)")
                     axs.set_ylabel("Calcium Concentrations")
                     fig.suptitle('Neuron %s' % neuron_id)


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Build calcium trace plots with a single subplot instead of reusing the electrode `E_mV` grid size
- Prevent calcium-only submissions from raising `NameError` and multi-site electrode submissions from producing an axes array where a single axes is expected

## Verification
- python3 -m py_compile Challenge/SubmissionConverter/SubmissionVisualizer.py
- focused source probe confirming the calcium block no longer references `E_mV` or `add_gridspec`
- git diff --check
- clean patch apply against fresh origin/main
- attempted matplotlib rendering probe; blocked because matplotlib is not installed for python3.10 or python3 in this environment