### PR TITLE
Fix model calcium plot axes

### DIFF
--- a/src/models/e0_bs/bs_vbp01_doubleblind_x_acquisition.py
+++ b/src/models/e0_bs/bs_vbp01_doubleblind_x_acquisition.py
@@ -377,9 +377,7 @@ else:
                 if len(neuron_Ca_data) < 1:
                     print('No Calcium concentration data for neuron '+neuron_id)
                 else:
-                    fig = plt.figure(figsize=figspecs['figsize'])
-                    gs = fig.add_gridspec(len(E_mV),1, hspace=0)
-                    axs = gs.subplots(sharex=True, sharey=True)
+                    fig, axs = plt.subplots(figsize=figspecs['figsize'])
                     axs.set_xlabel("Time (ms)")
                     axs.set_ylabel("Calcium Concentrations")
                     fig.suptitle('Neuron %s' % neuron_id)

--- a/src/models/xor_bs/xor_bs_acquisition.py
+++ b/src/models/xor_bs/xor_bs_acquisition.py
@@ -375,9 +375,7 @@ else:
                 if len(neuron_Ca_data) < 1:
                     print('No Calcium concentration data for neuron '+neuron_id)
                 else:
-                    fig = plt.figure(figsize=figspecs['figsize'])
-                    gs = fig.add_gridspec(len(E_mV),1, hspace=0)
-                    axs = gs.subplots(sharex=True, sharey=True)
+                    fig, axs = plt.subplots(figsize=figspecs['figsize'])
                     axs.set_xlabel("Time (ms)")
                     axs.set_ylabel("Calcium Concentrations")
                     fig.suptitle('Neuron %s' % neuron_id)

--- a/src/models/xor_sc/ConferenceAcquisition.py
+++ b/src/models/xor_sc/ConferenceAcquisition.py
@@ -424,9 +424,7 @@ else:
                 if len(neuron_Ca_data) < 1:
                     print('No Calcium concentration data for neuron '+neuron_id)
                 else:
-                    fig = plt.figure(figsize=figspecs['figsize'])
-                    gs = fig.add_gridspec(len(E_mV),1, hspace=0)
-                    axs = gs.subplots(sharex=True, sharey=True)
+                    fig, axs = plt.subplots(figsize=figspecs['figsize'])
                     axs.set_xlabel("Time (ms)")
                     axs.set_ylabel("Calcium Concentrations")
                     fig.suptitle('Neuron %s' % neuron_id)

--- a/src/models/xor_sc/xor_sc_acquisition.py
+++ b/src/models/xor_sc/xor_sc_acquisition.py
@@ -438,9 +438,7 @@ else:
                 if len(neuron_Ca_data) < 1:
                     print('No Calcium concentration data for neuron '+neuron_id)
                 else:
-                    fig = plt.figure(figsize=figspecs['figsize'])
-                    gs = fig.add_gridspec(len(E_mV),1, hspace=0)
-                    axs = gs.subplots(sharex=True, sharey=True)
+                    fig, axs = plt.subplots(figsize=figspecs['figsize'])
                     axs.set_xlabel("Time (ms)")
                     axs.set_ylabel("Calcium Concentrations")
                     fig.suptitle('Neuron %s' % neuron_id)


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Build model acquisition calcium trace plots with a single subplot instead of reusing the electrode `E_mV` grid size
- Prevent calcium-only runs from depending on electrode data and avoid axes-array misuse after multi-site electrode plots

## Verification
- python3 -m py_compile src/models/xor_bs/xor_bs_acquisition.py src/models/e0_bs/bs_vbp01_doubleblind_x_acquisition.py src/models/xor_sc/ConferenceAcquisition.py src/models/xor_sc/xor_sc_acquisition.py
- focused source probe confirming active calcium blocks no longer use `fig.add_gridspec(len(E_mV), ...)`
- git diff --check
- clean patch apply against fresh origin/main
- attempted matplotlib rendering probe earlier in this environment; blocked because matplotlib is not installed for python3.10 or python3