### PR TITLE
Honor visualize cells figure size

### DIFF
--- a/src/components/visualize_cells.py
+++ b/src/components/visualize_cells.py
@@ -53,7 +53,7 @@ def plot_neuron_somas(pyramidal, pyramidal_size, interneurons, interneurons_size
     pyramidal_size = np.array(pyramidal_size)
     interneurons_size = np.array(interneurons_size)
 
-    fig = plt.figure(figsize=(8, 6))
+    fig = plt.figure(figsize=FIGSIZE)
     ax = fig.add_subplot(111, projection='3d')
 
     # Get the current axes limits
@@ -146,7 +146,7 @@ def plot_connections(ax, objects, conn_matrix, color="k", alpha=0.3):
 
 def plot_neurons(objects, connectionmatrix=None):
     """objects: list of dicts with type='sphere' or 'box'"""
-    fig = plt.figure(figsize=(8,8))
+    fig = plt.figure(figsize=FIGSIZE)
     ax = fig.add_subplot(111, projection='3d')
 
     for obj in objects:


### PR DESCRIPTION
I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Summary
- Use the parsed `-x`/`-y` `FIGSIZE` value in both `visualize_cells.py` plotting functions
- Stop hard-coding 8-inch figure dimensions after exposing CLI size options

## Verification
- python3 -m py_compile src/components/visualize_cells.py
- python3.10 smoke test with fake matplotlib and a minimal pickle, confirming both figure calls use `(16.0, 10.0)`
- focused AST source probe confirming both `plt.figure()` calls use `figsize=FIGSIZE`
- git diff --check
- clean patch apply against fresh origin/main