### PR TITLE
Import PlotInfo for aligned circuit display

### DIFF
--- a/src/components/common/_BSAlignedNC.py
+++ b/src/components/common/_BSAlignedNC.py
@@ -8,6 +8,7 @@ neural circuits.
 
 from ._Geometry import Geometry
 from .NeuralCircuit import NeuralCircuit
+from .Spatial import PlotInfo
 
 class _BSAlignedNC(NeuralCircuit):
     '''


### PR DESCRIPTION
## Summary
- import `PlotInfo` where `_BSAlignedNC.show()` constructs a default plot context
- prevents `show(None)` from raising `NameError` before displaying cells

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile src/components/common/_BSAlignedNC.py
- python3.10 -m py_compile src/components/common/_BSAlignedNC.py
- focused `show(None)` smoke test with fake geometry/plot dependencies confirming the default `PlotInfo` is constructed
- focused source probe confirming the `PlotInfo` import and default show path
- git diff --check
- clean patch apply against origin/main