### PR TITLE
Avoid AIFinch mutable defaults

### DIFF
--- a/src/models/e3_aifinch/aifinch_vbp0_groundtruth.py
+++ b/src/models/e3_aifinch/aifinch_vbp0_groundtruth.py
@@ -59,12 +59,14 @@ class Sequence:
     A sequence of patterns.
     '''
     def __init__(self,
-        list_of_ids:list=[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ],
+        list_of_ids:list=None,
         pattern_size_mean:float=10,
         pattern_size_stdev:float=2,
         overlap_ratio_mean:float=0.1,
         overlap_ratio_stdev:float=0.01,):
-        self.list_of_ids = list_of_ids
+        if list_of_ids is None:
+            list_of_ids = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ]
+        self.list_of_ids = list(list_of_ids)
         self.patterns = []
         self.generate_patterns()
 
@@ -110,9 +112,11 @@ class AIF_DistributedAutoAssociative_NC(NeuralCircuit):
         ToDo('NES Team', 'Implement low-level modeling resources and API as required by AI Finch LTM VBP specs.')
 
     def Encode(self,
-        pattern_set=[ Sequence(), ],
+        pattern_set=None,
         encoding_method='instant',
         synapse_weight_method='binary',):
+        if pattern_set is None:
+            pattern_set = [ Sequence(), ]
         pass
         # TODO:
         # - Implement a variety of encoding methods and synapse weight methods.
@@ -134,9 +138,13 @@ class BrainRegion(Region):
     '''
     def __init__(self,
         id:str,
-        shape:Geometry=Cube(side_um=10.0),
-        content:NeuralCircuit=ArbitraryCells_NC(id='Arbitrary NC', num_cells=100),):
+        shape:Geometry=None,
+        content:NeuralCircuit=None,):
         super().__init__(id=id)
+        if shape is None:
+            shape = Cube(side_um=10.0)
+        if content is None:
+            content = ArbitraryCells_NC(id='Arbitrary NC', num_cells=100)
         self.shape = shape
         self.content = content
         # TODO:
@@ -155,8 +163,10 @@ class PatternGenerator(Region):
     '''
     def __init__(self,
         id:str,
-        pattern_set=[ Sequence(), ],):
+        pattern_set=None,):
         super().__init__(id=id)
+        if pattern_set is None:
+            pattern_set = [ Sequence(), ]
         self.pattern_set = pattern_set
 
     def random_selection(self,


### PR DESCRIPTION
## Summary
- replace eager Sequence, Cube, ArbitraryCells_NC, and list defaults with None sentinels
- construct fresh default objects per call for Sequence, Encode, BrainRegion, and PatternGenerator
- copy Sequence IDs so default and caller-provided iterables do not share list state

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile src/models/e3_aifinch/aifinch_vbp0_groundtruth.py
- AST probe confirming no list/dict/set/call defaults remain in the file
- import/default-isolation probe covering Sequence, BrainRegion, PatternGenerator, and Encode defaults
- git diff --check
- clean patch apply against origin/main in a detached worktree