### PR TITLE
Fix vbpcommon experiment DB values

### DIFF
--- a/src/models/autoassociative/vbpcommon.py
+++ b/src/models/autoassociative/vbpcommon.py
@@ -112,8 +112,8 @@ def PlotAndStoreRecordedActivity(recording_dict:dict, savefolder:str, figspecs:d
     return True
 
 def InitExpDB(_ExpsDB:str, _DBkey:str, _scriptversion:str, _initIN:dict, _initOUT:dict)->dict:
-    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion,
-    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S'),
+    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion
+    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S')
     return {
         'dbfile': _ExpsDB,
         'key': _DBkey,
@@ -202,7 +202,7 @@ def UpdateExpsDB(DBdata:dict)->bool:
 def ErrorToDB(DBdata:dict, errmsg:str):
     print(errmsg)
     if 'error' in DBdata['entry']['OUT']:
-        errmsg = DBdata['entry']['OUT']+'\n'+errmsg
+        errmsg = DBdata['entry']['OUT']['error']+'\n'+errmsg
     AddOutputToDB(DBdata, 'error', errmsg)
 
 def ErrorExit(DBdata:dict, errmsg:str):

--- a/src/models/full_adder_lifc/vbpcommon.py
+++ b/src/models/full_adder_lifc/vbpcommon.py
@@ -38,8 +38,8 @@ def PlotAndStoreRecordedActivity(recording_dict:dict, savefolder:str, figspecs:d
     return True
 
 def InitExpDB(_ExpsDB:str, _DBkey:str, _scriptversion:str, _initIN:dict, _initOUT:dict)->dict:
-    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion,
-    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S'),
+    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion
+    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S')
     return {
         'dbfile': _ExpsDB,
         'key': _DBkey,
@@ -128,7 +128,7 @@ def UpdateExpsDB(DBdata:dict)->bool:
 def ErrorToDB(DBdata:dict, errmsg:str):
     print(errmsg)
     if 'error' in DBdata['entry']['OUT']:
-        errmsg = DBdata['entry']['OUT']+'\n'+errmsg
+        errmsg = DBdata['entry']['OUT']['error']+'\n'+errmsg
     AddOutputToDB(DBdata, 'error', errmsg)
 
 def ErrorExit(DBdata:dict, errmsg:str):

--- a/src/models/xor_lifcnm/vbpcommon.py
+++ b/src/models/xor_lifcnm/vbpcommon.py
@@ -36,8 +36,8 @@ def PlotAndStoreRecordedActivity(recording_dict:dict, savefolder:str, figspecs:d
     return True
 
 def InitExpDB(_ExpsDB:str, _DBkey:str, _scriptversion:str, _initIN:dict, _initOUT:dict)->dict:
-    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion,
-    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S'),
+    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion
+    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S')
     return {
         'dbfile': _ExpsDB,
         'key': _DBkey,
@@ -126,7 +126,7 @@ def UpdateExpsDB(DBdata:dict)->bool:
 def ErrorToDB(DBdata:dict, errmsg:str):
     print(errmsg)
     if 'error' in DBdata['entry']['OUT']:
-        errmsg = DBdata['entry']['OUT']+'\n'+errmsg
+        errmsg = DBdata['entry']['OUT']['error']+'\n'+errmsg
     AddOutputToDB(DBdata, 'error', errmsg)
 
 def ErrorExit(DBdata:dict, errmsg:str):

--- a/src/models/xor_scnm/vbpcommon.py
+++ b/src/models/xor_scnm/vbpcommon.py
@@ -36,8 +36,8 @@ def PlotAndStoreRecordedActivity(recording_dict:dict, savefolder:str, figspecs:d
     return True
 
 def InitExpDB(_ExpsDB:str, _DBkey:str, _scriptversion:str, _initIN:dict, _initOUT:dict)->dict:
-    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion,
-    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S'),
+    _initIN['scriptversion'] = _DBkey+'-'+_scriptversion
+    _initIN['datetime'] = datetime.now().strftime('%Y%m%d%H%M%S')
     return {
         'dbfile': _ExpsDB,
         'key': _DBkey,
@@ -126,7 +126,7 @@ def UpdateExpsDB(DBdata:dict)->bool:
 def ErrorToDB(DBdata:dict, errmsg:str):
     print(errmsg)
     if 'error' in DBdata['entry']['OUT']:
-        errmsg = DBdata['entry']['OUT']+'\n'+errmsg
+        errmsg = DBdata['entry']['OUT']['error']+'\n'+errmsg
     AddOutputToDB(DBdata, 'error', errmsg)
 
 def ErrorExit(DBdata:dict, errmsg:str):


### PR DESCRIPTION
## Summary
- store scriptversion and datetime as strings instead of one-element tuples in vbpcommon experiment DB entries
- append repeated error messages from OUT["error"] instead of concatenating the whole OUT dict with a string
- apply the same fix to XOR SCNM, XOR LIFCNM, full-adder LIFC, and autoassociative helpers

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- python3 -m py_compile src/models/xor_scnm/vbpcommon.py src/models/xor_lifcnm/vbpcommon.py src/models/full_adder_lifc/vbpcommon.py src/models/autoassociative/vbpcommon.py
- focused runtime probe with stubbed external modules covering InitExpDB string values and repeated ErrorToDB appends for all four files
- focused source probe confirming tuple assignments and dict-string concat are gone
- git diff --check
- clean patch apply against origin/main in a detached worktree