### PR TITLE
Resolve XOR SCNM paths from scripts

### DIFF
--- a/src/models/xor_scnm/optimization/bayesian_optimization.py
+++ b/src/models/xor_scnm/optimization/bayesian_optimization.py
@@ -29,7 +29,7 @@ from pathlib import Path
 from datetime import datetime
 
 # Paths
-XOR_DIR = Path.home() / "BrainGenix/BrainEmulationChallenge/src/models/xor_scnm"
+XOR_DIR = Path(__file__).resolve().parents[1]
 CONFIG_FILE = "nesvbp-xor-res-sep-targets"
 RESERVOIR_SCRIPT = "./xor_scnm_groundtruth_reservoir.py"
 CONNECTOME_SCRIPT = "./xor_scnm_groundtruth_connectome.py"

--- a/src/models/xor_scnm/optimization/test_parameter_combinations.py
+++ b/src/models/xor_scnm/optimization/test_parameter_combinations.py
@@ -9,7 +9,7 @@ import argparse
 from pathlib import Path
 from datetime import datetime
 
-XOR_DIR = Path.home() / "BrainGenix/BrainEmulationChallenge/src/models/xor_scnm"
+XOR_DIR = Path(__file__).resolve().parents[1]
 CONFIG_FILE = "nesvbp-xor-res-sep-targets"
 RESERVOIR_SCRIPT = "./xor_scnm_groundtruth_reservoir.py"
 CONNECTOME_SCRIPT = "./xor_scnm_groundtruth_connectome.py"


### PR DESCRIPTION
## Summary
- derive XOR SCNM optimization paths from each script location instead of a hardcoded home-directory clone path
- preserve the existing config and subprocess behavior for normal runs

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3 -m py_compile src/models/xor_scnm/optimization/bayesian_optimization.py src/models/xor_scnm/optimization/test_parameter_combinations.py`
- import-style probe from a different working directory with dependency stubs confirmed both scripts resolve `XOR_DIR` to this repo
- `git diff --check`
- clean patch apply against a fresh `origin/main` clone