### PR TITLE
Use basename for client test images

### DIFF
--- a/src/components/pyBrainGenixClient/SimpleTest.py
+++ b/src/components/pyBrainGenixClient/SimpleTest.py
@@ -1,6 +1,7 @@
 # Simple Test Example For BG
 import time
 import base64
+from pathlib import PurePosixPath
 
 import BrainGenix.NES as NES
 
@@ -124,7 +125,10 @@ def main():
     for Image in ImageHandles:
         print(f"    -- Saving Image '{Image}'")
         ImageData = VSDAEMInstance.GetImage(Image)
-        with open(Image.split("/")[1],"wb") as FileHandler:
+        ImageFilename = PurePosixPath(Image).name
+        if not ImageFilename:
+            raise ValueError(f"Invalid image handle: {Image!r}")
+        with open(ImageFilename,"wb") as FileHandler:
             FileHandler.write(base64.decodebytes(ImageData))
 
 


### PR DESCRIPTION
## Summary
- save pyBrainGenixClient SimpleTest images using a POSIX basename instead of `Image.split("/")[1]`
- support plain filenames and nested image handles without crashing or selecting the wrong component
- reject empty image-handle filenames before writing

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.

## Verification
- `python3 -m py_compile src/components/pyBrainGenixClient/SimpleTest.py`
- focused filename extraction probe for plain, nested, and invalid handles
- `git diff --check`
- clean patch apply against a fresh `origin/main` clone