### PR TITLE
Parse XOR SC boolean args explicitly

### DIFF
--- a/src/models/xor_sc/vbpcommon.py
+++ b/src/models/xor_sc/vbpcommon.py
@@ -1,4 +1,17 @@
 # Enable common components used by multiple models:
+import argparse
 from sys import path
 from pathlib import Path
 path.insert(0, str(Path(__file__).parent.parent.parent)+'/components')
+
+def ParseBool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+
+    raise argparse.ArgumentTypeError("Expected a boolean value")

--- a/src/models/xor_sc/xor_sc_validation.py
+++ b/src/models/xor_sc/xor_sc_validation.py
@@ -43,7 +43,7 @@ Parser.add_argument(
     "-Port", default=8000, type=int, help="Port number to connect to"
 )
 Parser.add_argument(
-    "-UseHTTPS", default=False, type=bool, help="Enable or disable HTTPS"
+    "-UseHTTPS", nargs="?", const=True, default=False, type=vbpcommon.ParseBool, help="Enable or disable HTTPS"
 )
 Args = Parser.parse_args()
 


### PR DESCRIPTION
Summary
- Add an explicit boolean parser for the XOR SC model helper.
- Preserve bare -UseHTTPS as true while allowing explicit false values such as false, 0, no, and off.
- Update xor_sc_validation.py so string values like false no longer evaluate truthy.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile src/models/xor_sc/vbpcommon.py src/models/xor_sc/xor_sc_validation.py\n- rg -n "type\\s*=\\s*bool" src/models/xor_sc -g "*.py"\n- Focused AST/argparse probe for true values, false values, invalid values, default false, bare flag true, explicit false, and the updated -UseHTTPS add_argument call.\n- git diff --check\n- Clean patch apply against fresh origin/main.