### PR TITLE
Use current EM region when stitching conference output

### DIFF
--- a/src/models/xor_sc/ConferenceAcquisition.py
+++ b/src/models/xor_sc/ConferenceAcquisition.py
@@ -568,7 +568,7 @@ if (Args.RenderEM):
 
             print(" -- Reconstructing Image Stack")
             os.makedirs(f"{savefolder}/EMRegions/{i}")
-            StackStitcher.StitchManySlices(f"{savefolder}/ChallengeOutput/EMRegions/0/Data", f"{savefolder}/EMRegions/0", borderSizePx=3, nWorkers=os.cpu_count(), makeGIF=False)
+            StackStitcher.StitchManySlices(f"{savefolder}/ChallengeOutput/EMRegions/{i}/Data", f"{savefolder}/EMRegions/{i}", borderSizePx=3, nWorkers=os.cpu_count(), makeGIF=False)
 
         # if (Args.Neuroglancer):
             # NeuroglancerConverter(VSDAEMInstance, f"{savefolder}/NeuroglancerDataset")


### PR DESCRIPTION
Summary
- Fix ConferenceAcquisition EM stack reconstruction to stitch the region currently being rendered.
- Use EMRegions/{i} for both the downloaded stack input and stitched output paths instead of always reading and writing EMRegions/0.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile src/models/xor_sc/ConferenceAcquisition.py\n- Focused AST/source probe confirming the StitchManySlices paths use the loop index and the hard-coded EMRegions/0 call is gone.\n- git diff --check\n- Clean patch apply against fresh origin/main.