### PR TITLE
Parse full adder boolean args explicitly

### DIFF
--- a/src/models/full_adder_lifc/full_adder_lifc.py
+++ b/src/models/full_adder_lifc/full_adder_lifc.py
@@ -37,10 +37,23 @@ from NES_interfaces.KGTRecords import plot_recorded
 import BrainGenix.NES as NES
 
 
+def ParseBool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+
+    raise argparse.ArgumentTypeError("Expected a boolean value")
+
+
 Parser = argparse.ArgumentParser(description="LIFCNeuron test script")
 Parser.add_argument("-Host", default="localhost", type=str, help="Host to connect to")
 Parser.add_argument("-Port", default=8000, type=int, help="Port number to connect to")
-Parser.add_argument("-UseHTTPS", default=False, type=bool, help="Enable or disable HTTPS")
+Parser.add_argument("-UseHTTPS", nargs="?", const=True, default=False, type=ParseBool, help="Enable or disable HTTPS")
 Parser.add_argument("-ExpsDB", default="./ExpsDB.json", type=str, help="Path to experiments database JSON file")
 Parser.add_argument("-STDP", action="store_true", help="Enable STDP")
 Parser.add_argument("-Seed", default=0, type=int, help="Set random seed")
@@ -694,4 +707,3 @@ if isinstance(recording_dict, dict):
         print("Error: Recording data is missing or empty")
 else:
     print("Error: Invalid recording format received")
-


### PR DESCRIPTION
Summary
- Add an explicit boolean parser to the full-adder LIFC script.
- Preserve bare -UseHTTPS as true while allowing explicit false values such as false, 0, no, and off.
- Avoid argparse type=bool so string values like false no longer evaluate truthy.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile src/models/full_adder_lifc/full_adder_lifc.py\n- Focused AST/argparse probe for true values, false values, invalid values, default false, bare flag true, explicit false, and the updated -UseHTTPS add_argument call.\n- git diff --check\n- Clean patch apply against fresh origin/main.