### PR TITLE
Parse direct acquisition boolean args explicitly

### DIFF
--- a/src/models/full_adder_lifc/xor_scnm_acquisition_direct.py
+++ b/src/models/full_adder_lifc/xor_scnm_acquisition_direct.py
@@ -36,6 +36,18 @@ from BrainGenix.Tools.StackStitcher import StackStitcher, CaImagingStackStitcher
 def PointsInCircum(r, n=100):
     return [(math.cos(2*math.pi/n*x)*r,math.sin(2*math.pi/n*x)*r) for x in range(0,n+1)]
 
+def ParseBool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+
+    raise argparse.ArgumentTypeError("Expected a boolean value")
+
 
 # Handle Arguments for Host, Port, etc
 Parser = argparse.ArgumentParser(description="vbp script")
@@ -53,7 +65,7 @@ Parser.add_argument("-Host", default="localhost", type=str, help="Host to connec
 Parser.add_argument("-Port", default=8000, type=int, help="Port number to connect to")
 Parser.add_argument("-Resolution_um", default=0.05, type=float, help="Resolution in microns of each voxel")
 Parser.add_argument("-SubdivideSize", default=5, type=int, help="Amount to subdivide region in, 1 is full size, 2 is half size, etc.")
-Parser.add_argument("-UseHTTPS", default=False, type=bool, help="Enable or disable HTTPS")
+Parser.add_argument("-UseHTTPS", nargs="?", const=True, default=False, type=ParseBool, help="Enable or disable HTTPS")
 Parser.add_argument("-DownloadEM", action="store_true", help="Enable downloading of EM Images")
 Parser.add_argument("-ExpsDB", default="./ExpsDB.json", type=str, help="Path to experiments database JSON file")
 Args = Parser.parse_args()

--- a/src/models/xor_lifcnm/xor_lifcnm_acquisition_direct.py
+++ b/src/models/xor_lifcnm/xor_lifcnm_acquisition_direct.py
@@ -32,6 +32,18 @@ from BrainGenix.Tools.StackStitcher import StackStitcher, CaImagingStackStitcher
 def PointsInCircum(r, n=100):
     return [(math.cos(2*math.pi/n*x)*r,math.sin(2*math.pi/n*x)*r) for x in range(0,n+1)]
 
+def ParseBool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+
+    raise argparse.ArgumentTypeError("Expected a boolean value")
+
 
 # Handle Arguments for Host, Port, etc
 Parser = argparse.ArgumentParser(description="vbp script")
@@ -49,7 +61,7 @@ Parser.add_argument("-Host", default="localhost", type=str, help="Host to connec
 Parser.add_argument("-Port", default=8000, type=int, help="Port number to connect to")
 Parser.add_argument("-Resolution_um", default=0.05, type=float, help="Resolution in microns of each voxel")
 Parser.add_argument("-SubdivideSize", default=5, type=int, help="Amount to subdivide region in, 1 is full size, 2 is half size, etc.")
-Parser.add_argument("-UseHTTPS", default=False, type=bool, help="Enable or disable HTTPS")
+Parser.add_argument("-UseHTTPS", nargs="?", const=True, default=False, type=ParseBool, help="Enable or disable HTTPS")
 Parser.add_argument("-DownloadEM", action="store_true", help="Enable downloading of EM Images")
 Parser.add_argument("-ExpsDB", default="./ExpsDB.json", type=str, help="Path to experiments database JSON file")
 Args = Parser.parse_args()

--- a/src/models/xor_scnm/xor_scnm_acquisition_direct.py
+++ b/src/models/xor_scnm/xor_scnm_acquisition_direct.py
@@ -32,6 +32,18 @@ from BrainGenix.Tools.StackStitcher import StackStitcher, CaImagingStackStitcher
 def PointsInCircum(r, n=100):
     return [(math.cos(2*math.pi/n*x)*r,math.sin(2*math.pi/n*x)*r) for x in range(0,n+1)]
 
+def ParseBool(value):
+    if isinstance(value, bool):
+        return value
+
+    normalized = value.lower()
+    if normalized in ("true", "1", "yes", "on"):
+        return True
+    if normalized in ("false", "0", "no", "off"):
+        return False
+
+    raise argparse.ArgumentTypeError("Expected a boolean value")
+
 
 # Handle Arguments for Host, Port, etc
 Parser = argparse.ArgumentParser(description="vbp script")
@@ -49,7 +61,7 @@ Parser.add_argument("-Host", default="localhost", type=str, help="Host to connec
 Parser.add_argument("-Port", default=8000, type=int, help="Port number to connect to")
 Parser.add_argument("-Resolution_um", default=0.05, type=float, help="Resolution in microns of each voxel")
 Parser.add_argument("-SubdivideSize", default=5, type=int, help="Amount to subdivide region in, 1 is full size, 2 is half size, etc.")
-Parser.add_argument("-UseHTTPS", default=False, type=bool, help="Enable or disable HTTPS")
+Parser.add_argument("-UseHTTPS", nargs="?", const=True, default=False, type=ParseBool, help="Enable or disable HTTPS")
 Parser.add_argument("-DownloadEM", action="store_true", help="Enable downloading of EM Images")
 Parser.add_argument("-ExpsDB", default="./ExpsDB.json", type=str, help="Path to experiments database JSON file")
 Args = Parser.parse_args()


### PR DESCRIPTION
Summary
- Add local explicit boolean parsers to the direct acquisition scripts that still used argparse type=bool.
- Update -UseHTTPS in XOR SCNM, XOR LIFCNM, and full-adder direct acquisition scripts.
- Preserve bare -UseHTTPS as true while allowing explicit false values such as false, 0, no, and off.

I can't use the GitLab instance from this machine, so I'm submitting this through the GitHub mirror.\n\nVerification\n- python3 -m py_compile src/models/xor_scnm/xor_scnm_acquisition_direct.py src/models/xor_lifcnm/xor_lifcnm_acquisition_direct.py src/models/full_adder_lifc/xor_scnm_acquisition_direct.py\n- rg -n "type\\s*=\\s*bool" on the three touched scripts\n- Focused AST/argparse probe for true values, false values, invalid values, default false, bare flag true, explicit false, and the updated -UseHTTPS add_argument calls.\n- git diff --check\n- Clean patch apply against fresh origin/main.\n- Patch apply check after applying BEC PR #21 completed without conflicts.